### PR TITLE
Cleanup formatting and group customizable parameters

### DIFF
--- a/org_pulse.rb
+++ b/org_pulse.rb
@@ -3,11 +3,13 @@ Bundler.require
 Dotenv.load
 require 'active_support/core_ext/string/inflections'
 
+# Override org and dates to customize
 org = 'librariesio'
-access_token = ENV['GITHUB_TOKEN']
-client = Octokit::Client.new(access_token: access_token, auto_paginate: true)
 start_date = '2016-12-01'
 end_date = '2016-12-31'
+
+access_token = ENV['GITHUB_TOKEN']
+client = Octokit::Client.new(access_token: access_token, auto_paginate: true)
 
 repos = client.org_repos(org)
 
@@ -30,11 +32,11 @@ repos.sort_by(&:stars).reverse.each do |repo|
   merged_pull_requests = pull_requests.select{|i| i.merged_at && i.merged_at > Date.parse(start_date).to_time && i.merged_at < Date.parse(end_date).to_time }
 
   if commits.length > 0 || merged_pull_requests.length > 0 || closed_issues.length > 0
-    puts "### [#{repo.name}](https://github.com/#{repo.full_name})"
+    puts "\n### [#{repo.name}](https://github.com/#{repo.full_name})\n"
     puts "-  [#{commits.length} #{'commit'.pluralize(commits.length)}](https://github.com/#{repo.full_name}/compare/master@%7B#{Date.parse(start_date).to_time.to_i}%7D...master@%7B#{Date.parse(end_date).to_time.to_i}%7D)" if commits.length > 0
-    puts "-  [#{closed_issues.length} closed  #{'issue'.pluralize(closed_issues.length)}](https://github.com/#{repo.full_name}/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A#{start_date}..#{end_date})" if closed_issues.length > 0
+    puts "-  [#{closed_issues.length} closed #{'issue'.pluralize(closed_issues.length)}](https://github.com/#{repo.full_name}/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A#{start_date}..#{end_date})" if closed_issues.length > 0
     if merged_pull_requests.any?
-      puts "#### Merged pull requests"
+      puts "\n#### Merged pull requests\n"
       merged_pull_requests.each do |pr|
         puts "- [#{pr.title}](#{pr.html_url}) by [#{pr.user.login}](#{pr.user.html_url})"
       end
@@ -42,7 +44,7 @@ repos.sort_by(&:stars).reverse.each do |repo|
   end
 end
 
-puts "## Totals"
+puts "\n## Totals\n"
 puts "- Commits: #{total_commits}"
 puts "- Pull requests: #{total_pull_requests}"
 puts "- Issues: #{total_issues}"


### PR DESCRIPTION
This PR provides minor edits to:

- group customizable parameters which are useful when using with a different org
- edit formatting to be more GitHub markdown friendly (This is helpful when executing
  `ruby org_pulse.rb > report.md` and later committing the markdown report to GitHub)
- remove extra space in `closed issue` count output

---
Thanks for sharing this script. It works great and I'm happy to see more tools that work across an org. Thanks!